### PR TITLE
feat: responsive portfolio redesign

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,11 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="style.css">
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
     <title>devils._.snare | About</title>
 </head>
 <body>
     <header class="header">
         <a href="index.html" class="logo">devils._.snare</a>
+
+        <div id="menu-icon"><i class='bx bx-menu'></i></div>
 
         <nav class="navbar">
             <a href="index.html">Home</a>
@@ -37,5 +40,7 @@
         <p><strong>Weird Hobby:</strong> Collecting random facts. Did you know honey never spoils? It might outlast my gaming addiction.</p>
     </div>
     </section>
+
+    <script src="script.js"></script>
 </body>
 </html>

--- a/brainfuck.css
+++ b/brainfuck.css
@@ -28,6 +28,7 @@ body {
     justify-content: center;
     align-items: center;
     flex-direction: column;
+    padding: 20px;
 }
 
 i {
@@ -74,4 +75,21 @@ button:nth-child(1) {
 button:nth-child(2) {
     margin-right: -200px;
     color: #00abf0;
+}
+
+@media (max-width: 600px) {
+    .wrapper {
+        width: 90%;
+        height: auto;
+    }
+
+    .btn-group {
+        flex-direction: column;
+        height: auto;
+    }
+
+    button {
+        position: static;
+        margin: 10px 0;
+    }
 }

--- a/brainfuck.html
+++ b/brainfuck.html
@@ -12,6 +12,8 @@
     <header class="header">
         <a href="index.html" class="logo">devils._.snare</a>
 
+        <div id="menu-icon"><i class='bx bx-menu'></i></div>
+
         <nav class="navbar">
             <a href="index.html">Home</a>
             <a href="about.html">About</a>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <header class="header">
         <a href="index.html" class="logo">devils._.snare</a>
 
+        <div id="menu-icon"><i class='bx bx-menu'></i></div>
+
         <nav class="navbar">
             <a href="index.html" class="active">Home</a>
             <a href="about.html">About</a>
@@ -27,11 +29,14 @@
             <h1>Hi, I'm devils._.snare</h1>
             <h3>Student and Developer</h3>
             <p> I'm devils._.snare, but you can call me Faiq (because my mom does). I'm a teenage tech geek from EMEA who loves computers, gaming, coding, and literature—basically, I'm a nerd with a need for something (?). I'm also a certified Discord degenerate, and if I don't touch grass soon, I might just become one with my chair.</p>
-            <p>An image was supposed to go on the right - but its not there...</p>
             <div class="btn-box">
                 <a href="randomPg.html">Some Link</a>
                 <a href="about.html">About</a>
             </div>
+        </div>
+
+        <div class="home-img">
+            <img src="media/img1.png" alt="Profile picture">
         </div>
 
         <div class="home-sci">
@@ -41,12 +46,6 @@
         </div>
     </section>
 
-     <!-- Warning Content for Small Screens -->
-    <div class="warning-container">
-        <h1>!!You have been warned!!</h1>
-        <h2>This website looks shit on smaller devices!</h2>
-        <p>View this on a PC!</p>
-        <p>Sorry - but I was EXTREMELY lazy and did not add media queries for smaller devices...</p>
-    </div>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/randomPg.html
+++ b/randomPg.html
@@ -5,10 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>devils._.snare | Random Page</title>
     <link rel="stylesheet" href="style.css">
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
 </head>
 <body>
     <header class="header">
         <a href="index.html" class="logo">devils._.snare</a>
+
+        <div id="menu-icon"><i class='bx bx-menu'></i></div>
 
         <nav class="navbar">
             <a href="index.html">Home</a>
@@ -24,8 +27,10 @@
             <p>You fell for it! Have a nice day :)</p>
         </div>
         <div class="vidRnd">
-            <video src="./media/vid1.mp4" width="800" height="900" title="Something Random" frameborder="0" autoplay loop></video>
+            <video src="./media/vid1.mp4" title="Something Random" frameborder="0" autoplay loop></video>
         </div>
     </section>
+
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,19 +1,32 @@
+// Mobile navigation toggle
+const menuIcon = document.querySelector('#menu-icon');
+const navbar = document.querySelector('.navbar');
+
+if (menuIcon && navbar) {
+    menuIcon.addEventListener('click', () => {
+        navbar.classList.toggle('active');
+    });
+}
+
+// Brainfuck page interaction
 const wrapper = document.querySelector('.wrapper');
 const question = document.querySelector('.question');
 const yesBtn = document.querySelector('.yes-btn');
 const noBtn = document.querySelector('.no-btn');
 
-const wrapperRect = wrapper.getBoundingClientRect();
-const noBtnRect = noBtn.getBoundingClientRect();
+if (wrapper && question && yesBtn && noBtn) {
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const noBtnRect = noBtn.getBoundingClientRect();
 
-yesBtn.addEventListener('click', () => {
-    question.innerHTML = 'Great! New brain fucks soon :)';
-});
+    yesBtn.addEventListener('click', () => {
+        question.innerHTML = 'Great! New brain fucks soon :)';
+    });
 
-noBtn.addEventListener('mouseover', () => {
-    const i = Math.floor(Math.random() * (wrapperRect.width - noBtnRect.width)) + 1;
-    const j = Math.floor(Math.random() * (wrapperRect.height - noBtnRect.height)) + 1;
+    noBtn.addEventListener('mouseover', () => {
+        const i = Math.floor(Math.random() * (wrapperRect.width - noBtnRect.width)) + 1;
+        const j = Math.floor(Math.random() * (wrapperRect.height - noBtnRect.height)) + 1;
 
-    noBtn.style.left = i + 'px';
-    noBtn.style.top = j + 'px';
-});
+        noBtn.style.left = i + 'px';
+        noBtn.style.top = j + 'px';
+    });
+}

--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@
 }
 
 body {
-    background: #081b29;
+    background: linear-gradient(135deg, #081b29, #0d2845);
     color: #ededed;
 }
 
@@ -30,6 +30,13 @@ body {
     color: #ededed;
     text-decoration: none;
     font-weight: 600;
+}
+
+#menu-icon {
+    font-size: 28px;
+    color: #ededed;
+    cursor: pointer;
+    display: none;
 }
 
 .navbar a {
@@ -55,6 +62,17 @@ body {
 
 .home-content {
     max-width: 600px;
+}
+
+.home-img {
+    width: 35%;
+    text-align: center;
+}
+
+.home-img img {
+    width: 100%;
+    max-width: 300px;
+    border-radius: 50%;
 }
 
 .home-content h1 {
@@ -250,64 +268,86 @@ body {
     padding: 10px 0; /* Add padding if you need some space inside the paragraphs */
 }
 
-/* Base styles for visibility */
-.warning-container {
-    display: none; /* Hide by default */
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: #081b29;
-    color: #ededed;
-    padding: 20px;
-    border: 2px solid #f00;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-    text-align: center;
-    max-width: 90%;
-    width: 400px;
-    border-radius: 8px;
-}
-
-.warning-container h1 {
-    color: #f00;
-    font-size: 24px;
-}
-
-.warning-container h2 {
-    font-size: 20px;
-}
-
-.warning-container p {
-    font-size: 16px;
-    margin: 10px 0;
-}
-
-.btn-box.buttonCust a {
-    display: inline-block;
-    padding: 10px 20px;
-    text-decoration: none;
-    background-color: #f00;
-    color: #fff;
-    border-radius: 5px;
-    margin-top: 20px;
-}
-
-.btn-box.buttonCust a:hover {
-    background-color: #c00;
-}
-
-/* Hide Main Content for Small Screens */
-@media (max-width: 900px) {
-    /* Hide main content */
-    .header, .home, .home-sci, .navbar {
-        display: none;
+/* Responsive Styles */
+@media (max-width: 768px) {
+    #menu-icon {
+        display: block;
     }
 
-    /* Show warning content */
-    .warning-container {
-        display: flex;
+    .navbar {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        width: 100%;
+        background: #081b29;
+        display: none;
         flex-direction: column;
-        align-items: center;
+        padding: 10px 0;
+    }
+
+    .navbar.active {
+        display: flex;
+    }
+
+    .navbar a {
+        margin: 10px 0;
+        display: block;
+        text-align: center;
+    }
+
+    .home {
+        flex-direction: column;
         justify-content: center;
+        text-align: center;
+        padding: 70px 5%;
+    }
+
+    .home-content {
+        max-width: 100%;
+    }
+
+    .home-img {
+        width: 100%;
+        margin-top: 40px;
+    }
+
+    .home-img img {
+        max-width: 200px;
+    }
+
+    .home-content .btn-box {
+        flex-direction: column;
+        width: 100%;
+        height: auto;
+    }
+
+    .btn-box a {
+        width: 100%;
+        margin: 10px 0;
+    }
+
+    .home-sci {
+        position: static;
+        margin-top: 20px;
+        justify-content: center;
+    }
+
+    .contentContainer {
+        flex-direction: column;
+        height: auto;
+        padding: 80px 5%;
+    }
+
+    .home-contentRnd, .vidRnd {
+        max-width: 100%;
+    }
+
+    .vidRnd {
+        justify-content: center;
+    }
+
+    .about {
+        flex-direction: column;
+        margin-top: 80px;
     }
 }


### PR DESCRIPTION
## Summary
- add mobile-friendly navigation with hamburger menu
- refresh hero section with profile image and gradient background
- apply responsive media queries across pages including brainfuck game

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adbb0dd520832184fcbb4c87b2bc62